### PR TITLE
Allow C code to be profiled

### DIFF
--- a/N2A/src/gov/sandia/n2a/backend/c/JobC.java
+++ b/N2A/src/gov/sandia/n2a/backend/c/JobC.java
@@ -866,7 +866,16 @@ public class JobC extends Thread
         generateDeclarationsLocal (s, result);
         generateDeclarationsGlobal (s, result);
     }
-
+    public void push_region(StringBuilder result, String name) {
+        if(with_profiling) {
+          result.append("push_region(\""+name+"\");\n");
+        }
+    }
+    public void pop_region(StringBuilder result) {
+        if(with_profiling) {
+            result.append("pop_region();\n");
+        }
+    }
     public void generateDeclarationsGlobal (EquationSet s, StringBuilder result)
     {
         BackendDataC bed = (BackendDataC) s.backendData;
@@ -1498,6 +1507,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "integrate ()\n");
             result.append ("{\n");
+            push_region(result,ns+"integrate()");
             result.append ("  EventStep<" + T + "> * event = getEvent ();\n");
             context.hasEvent = true;
             result.append ("  " + T + " dt = event->dt;\n");
@@ -1537,6 +1547,7 @@ public class JobC extends Thread
             }
             result.append ("  }\n");
             context.hasEvent = false;
+            pop_region(result);
             result.append ("}\n");
             result.append ("\n");
         }
@@ -1546,9 +1557,9 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "update ()\n");
             result.append ("{\n");
-            if(with_profiling) {
-              result.append ("push_region(\""+ ns +"::update()"+"\");\n");
-            }
+              
+            push_region(result,ns +"::update()");
+            
             for (Variable v : bed.globalBufferedInternalUpdate)
             {
                 result.append ("  " + type (v) + " " + mangle ("next_", v) + ";\n");
@@ -1563,9 +1574,7 @@ public class JobC extends Thread
             {
                 result.append ("  " + mangle (v) + " = " + mangle ("next_", v) + ";\n");
             }
-            if(with_profiling) {
-                result.append ("pop_region();\n");
-            }
+            pop_region(result);
             result.append ("}\n");
             result.append ("\n");
         }
@@ -1680,6 +1689,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "updateDerivative ()\n");
             result.append ("{\n");
+            push_region(result,ns + "updateDerivative()");
             for (Variable v : bed.globalBufferedInternalDerivative)
             {
                 result.append ("  " + type (v) + " " + mangle ("next_", v) + ";\n");
@@ -1694,6 +1704,7 @@ public class JobC extends Thread
             {
                 result.append ("  " + mangle (v) + " = " + mangle ("next_", v) + ";\n");
             }
+            pop_region(result);
             result.append ("}\n");
             result.append ("\n");
         }
@@ -2371,6 +2382,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "integrate ()\n");
             result.append ("{\n");
+            push_region(result,ns+"integrate()");
             if (bed.localIntegrated.size () > 0)
             {
                 if (bed.lastT)
@@ -2432,6 +2444,7 @@ public class JobC extends Thread
                 }
             }
             context.hasEvent = false;
+            pop_region(result);
             result.append ("}\n");
             result.append ("\n");
         }
@@ -2441,9 +2454,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "update ()\n");
             result.append ("{\n");
-            if(with_profiling) {
-                result.append ("push_region(\""+ ns +"::update()"+"\");\n");
-            }
+            push_region(result,ns +"::update()");
             for (Variable v : bed.localBufferedInternalUpdate)
             {
                 result.append ("  " + type (v) + " " + mangle ("next_", v) + ";\n");
@@ -2466,9 +2477,7 @@ public class JobC extends Thread
                     result.append ("  " + mangle (e.name) + ".update ();\n");
                 }
             }
-            if(with_profiling) {
-                result.append ("pop_region();\n");
-            }
+            pop_region(result);
             
             result.append ("}\n");
             result.append ("\n");
@@ -2708,6 +2717,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "updateDerivative ()\n");
             result.append ("{\n");
+            push_region(result, ns+"updateDerivative()");
             for (Variable v : bed.localBufferedInternalDerivative)
             {
                 result.append ("  " + type (v) + " " + mangle ("next_", v) + ";\n");
@@ -2730,6 +2740,7 @@ public class JobC extends Thread
                     result.append ("  " + mangle (e.name) + ".updateDerivative ();\n");
                 }
             }
+            pop_region(result);
             result.append ("}\n");
             result.append ("\n");
         }

--- a/N2A/src/gov/sandia/n2a/backend/c/JobC.java
+++ b/N2A/src/gov/sandia/n2a/backend/c/JobC.java
@@ -1558,7 +1558,7 @@ public class JobC extends Thread
             result.append ("void " + ns + "update ()\n");
             result.append ("{\n");
               
-            push_region(result,ns +"::update()");
+            push_region(result,ns +"update()");
             
             for (Variable v : bed.globalBufferedInternalUpdate)
             {
@@ -2454,7 +2454,7 @@ public class JobC extends Thread
         {
             result.append ("void " + ns + "update ()\n");
             result.append ("{\n");
-            push_region(result,ns +"::update()");
+            push_region(result,ns +"update()");
             for (Variable v : bed.localBufferedInternalUpdate)
             {
                 result.append ("  " + type (v) + " " + mangle ("next_", v) + ";\n");

--- a/N2A/src/gov/sandia/n2a/backend/c/runtime/profiling.cc
+++ b/N2A/src/gov/sandia/n2a/backend/c/runtime/profiling.cc
@@ -1,0 +1,50 @@
+#include<dlfcn.h>
+#include <string>
+#include <iostream>
+void(*push_region_cb)(const char*);
+void(*pop_region_cb)();
+void(*init_cb)(int loadseq, uint64_t version, uint32_t ndevinfos, void* devinfos);
+void(*finalize_cb)();
+void push_region(const std::string& kName) {
+  if ( push_region_cb != nullptr) {
+    (*push_region_cb)(kName.c_str());
+  }
+}
+
+void pop_region() {
+  if (pop_region_cb != nullptr) {
+    (*pop_region_cb)();
+  }
+}
+void get_callbacks() {
+      char* x = getenv("KOKKOS_PROFILE_LIBRARY");
+      void* firstProfileLibrary = nullptr;
+      if(x!=nullptr) {
+         firstProfileLibrary = dlopen(x, RTLD_NOW | RTLD_GLOBAL);
+      } else{
+	 // TODO: smrt error
+      }
+      if(firstProfileLibrary!=nullptr){
+        void* p9 = dlsym(firstProfileLibrary, "kokkosp_push_profile_region");
+        push_region_cb=
+            *reinterpret_cast<decltype(push_region_cb)*>(&p9);
+        void* p10 = dlsym(firstProfileLibrary, "kokkosp_pop_profile_region");
+        pop_region_cb = 
+            *reinterpret_cast<decltype(pop_region_cb)*>(&p10);
+
+        void* p11 = dlsym(firstProfileLibrary, "kokkosp_init_library");
+        init_cb = 
+            *reinterpret_cast<decltype(init_cb)*>(&p11);
+        void* p12 = dlsym(firstProfileLibrary, "kokkosp_finalize_library");
+        finalize_cb = 
+            *reinterpret_cast<decltype(finalize_cb)*>(&p12);
+         (*init_cb)(0,0,0,nullptr);
+      }
+      else {
+	      std::cout << "Bad dlopen\n";
+      }
+}
+void finalize_profiling() {
+  (*finalize_cb)();
+}
+

--- a/N2A/src/gov/sandia/n2a/backend/c/runtime/profiling.h
+++ b/N2A/src/gov/sandia/n2a/backend/c/runtime/profiling.h
@@ -1,0 +1,4 @@
+void get_callbacks();
+void push_region(const std::string&);
+void pop_region();
+void finalize_profiling();


### PR DESCRIPTION
I don't know how to submit the changes I made to the C runtime, I can share those with you too. But now if you set "profile" to "true" in a C backend, you get profiling calls in currently just the update functions, but we can expand that.