### PR TITLE
Implement others field to allow use of non-model and non-reference data structures within repos

### DIFF
--- a/N2A/src/gov/sandia/n2a/db/AppData.java
+++ b/N2A/src/gov/sandia/n2a/db/AppData.java
@@ -33,13 +33,13 @@ import java.util.zip.ZipInputStream;
 **/
 public class AppData
 {
-    public static MNode  properties;
-    public static MDoc   state;
-    public static MDir   runs;
-    public static MDir   studies;
-    public static MDir   repos;
-    public static MCombo models;
-    public static MCombo references;
+    public static MNode               properties;
+    public static MDoc                state;
+    public static MDir                runs;
+    public static MDir                studies;
+    public static MDir                repos;
+    public static MCombo              models;
+    public static MCombo              references;
     public static Map<String, MCombo> others;
 
     protected static boolean stop;

--- a/N2A/src/gov/sandia/n2a/db/AppData.java
+++ b/N2A/src/gov/sandia/n2a/db/AppData.java
@@ -97,11 +97,14 @@ public class AppData
                     String key = subfolder.getFileName ().toString ();
                     if (key.startsWith (".")) continue;
                     if (! Files.isDirectory (subfolder)) continue;
-                    if (! containers.containsKey (key))
+
+                    List<MNode> nodes = containers.get (key); 
+                    if (nodes == null)
                     {
-                        containers.put (key, new ArrayList<> ());
+                        nodes = new ArrayList<> ();
+                        containers.put (key, nodes);
                     }
-                    containers.get (key).add (new MDir(repoName, repoDir.resolve (key)));
+                    nodes.add (new MDir(repoName, repoDir.resolve (key)));
                 }
             }
             catch (IOException e) {}

--- a/N2A/src/gov/sandia/n2a/db/AppData.java
+++ b/N2A/src/gov/sandia/n2a/db/AppData.java
@@ -243,8 +243,6 @@ public class AppData
     public synchronized static void save ()
     {
         // Sorted from most critical to least, in terms of how damaging a loss of information would be.
-        models.save ();
-        references.save ();
         documents.forEach (c -> ((MCombo) c).save ());
         studies.save ();
         runs.save ();

--- a/N2A/src/gov/sandia/n2a/db/AppData.java
+++ b/N2A/src/gov/sandia/n2a/db/AppData.java
@@ -34,6 +34,7 @@ public class AppData
     public static MDir   repos;
     public static MCombo models;
     public static MCombo references;
+    public static Map<String, MCombo> others;
 
     protected static boolean stop;
 
@@ -92,6 +93,7 @@ public class AppData
         }
         models     = new MCombo ("models",     modelContainers);
         references = new MCombo ("references", referenceContainers);
+        others     = new HashMap<String, MCombo> ();
 
         //convert (modelContainers);
         //convert (referenceContainers);
@@ -226,6 +228,7 @@ public class AppData
         runs.save ();
         repos.save ();
         state.save ();
+        others.forEach ((k, v) -> v.save ());
     }
 
     public static void quit ()

--- a/N2A/src/gov/sandia/n2a/db/AppData.java
+++ b/N2A/src/gov/sandia/n2a/db/AppData.java
@@ -110,9 +110,8 @@ public class AppData
                     .filter (file -> !file.equals (".git"))
                     .collect (Collectors.toSet ());
             }
-            catch (IOException e)
+            catch (Exception e)
             {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
             temp.forEach ((subfolder) ->
@@ -128,6 +127,9 @@ public class AppData
         references = new MCombo ("references", referenceContainers);
         others     = new HashMap<String, MCombo> ();
         otherContainers.forEach ((k, v) -> others.put (k, new MCombo(k, v)));
+        
+        others.put ("models", models);
+        others.put ("references", references);
 
         //convert (modelContainers);
         //convert (referenceContainers);

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -50,6 +50,7 @@ import java.util.EventObject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -1136,9 +1137,13 @@ public class SettingsRepo extends JScrollPane implements Settings
             GitWrapper gitRepo = new GitWrapper (baseDir.resolve (".git"));
             gitRepo.setURL (URL);
             AppData.repos.set (1, name, "visible");  // Implicitly creates the repo node.
-            // Local variable temp must be final or effectively final to be used in the following forEach.
-            final String temp = name;
-            existing.forEach((k,v) -> v.put (temp, new MDir (temp, baseDir.resolve (k))));
+            for(Entry<String, Map<String, MNode>> e : existing.entrySet ())
+            {
+                String key = e.getKey ();
+                Map<String, MNode> value = e.getValue ();
+                value.put (name, new MDir (name, baseDir.resolve (key)));
+            }
+            
             needRebuild = true;
 
             repoModel.repos   .add (row, AppData.repos.child (name));

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -784,28 +784,23 @@ public class SettingsRepo extends JScrollPane implements Settings
             {
                 String k = e.getKey ();
                 MNode  v = e.getValue ();
+                List<MNode> nodes = existingContainers.get (k);
+                if(nodes == null) 
+                {
+                    existingContainers.put (k, new ArrayList<MNode> ());
+                    nodes = existingContainers.get(k);
+                }
                 if(isPrimary)
                 {
-                    List<MNode> nodes = existingContainers.get (k);
-                    if(nodes == null) 
-                    {
-                        existingContainers.put (k, new ArrayList<MNode> ());
-                        nodes = existingContainers.get(k);
-                    }
-                    nodes.add (0, v);
+                    nodes.add (0, v);                    
                 }
                 else 
                 {
-                    List<MNode> nodes = existingContainers.get (k);
-                    if(nodes == null) 
-                    {
-                        existingContainers.put (k, new ArrayList<MNode> ());
-                        nodes = existingContainers.get(k);
-                    }
                     nodes.add (v);
                 }
             }
         }
+        // Iterate over each container and initialize the corresponding MCombo.
         existingContainers.forEach ((k, v) -> ((MCombo) AppData.documents.childOrCreate (k)).init(v)); // Triggers change() call to PanelModel and PanelReference)
         needRebuild = false;
     }

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -804,7 +804,7 @@ public class SettingsRepo extends JScrollPane implements Settings
                 });
             }
         }
-        AppData.documents.forEach (c -> ((MCombo) c).init (existingContainers.get (c.key ()))); // Triggers change() call to PanelModel and PanelReference)
+        existingContainers.forEach ((k, v) -> ((MCombo) AppData.documents.childOrCreate (k)).init(v)); // Triggers change() call to PanelModel and PanelReference)
         needRebuild = false;
     }
 

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -1391,8 +1391,7 @@ public class SettingsRepo extends JScrollPane implements Settings
         public MDir getDir ()
         {
             String repoName = git.gitDir.getParent ().getFileName ().toString ();
-            String[] pieces = repoName.split ("/");
-            return getExisting(pieces[0], repoName);
+            return getExisting(name, repoName);
         }
 
         /**

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -780,9 +780,12 @@ public class SettingsRepo extends JScrollPane implements Settings
 
             Map<String, MNode> dirs = new HashMap<String, MNode> ();
             existing.forEach ((k,v) -> dirs.put(k, getExisting(k, repoName)));
-            if (isPrimary)
+            for (Entry<String, MNode> e : dirs.entrySet ())
             {
-                dirs.forEach ((k,v) -> {
+                String k = e.getKey ();
+                MNode  v = e.getValue ();
+                if(isPrimary)
+                {
                     List<MNode> nodes = existingContainers.get (k);
                     if(nodes == null) 
                     {
@@ -790,11 +793,9 @@ public class SettingsRepo extends JScrollPane implements Settings
                         nodes = existingContainers.get(k);
                     }
                     nodes.add (0, v);
-                });
-            }
-            else
-            {
-                dirs.forEach ((k,v) -> {
+                }
+                else 
+                {
                     List<MNode> nodes = existingContainers.get (k);
                     if(nodes == null) 
                     {
@@ -802,7 +803,7 @@ public class SettingsRepo extends JScrollPane implements Settings
                         nodes = existingContainers.get(k);
                     }
                     nodes.add (v);
-                });
+                }
             }
         }
         existingContainers.forEach ((k, v) -> ((MCombo) AppData.documents.childOrCreate (k)).init(v)); // Triggers change() call to PanelModel and PanelReference)

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -712,7 +712,7 @@ public class SettingsRepo extends JScrollPane implements Settings
                     MDir destination;
                     MCombo combo;
                     
-                    destination = (MDir) existing.get (pieces[0]).get (key);
+                    destination = (MDir) getExisting (pieces[0], key);
                     combo = (MCombo) AppData.documents.child (pieces[0]);
                     
                     destination.take (source, pieces[1]);
@@ -755,7 +755,7 @@ public class SettingsRepo extends JScrollPane implements Settings
         MDir result = (MDir) current.get (repoName);
         if (result == null)
         {
-            result = new MDir (repoName, reposDir.resolve (repoName).resolve (subfolder));
+            result = new MDir (repoName, reposDir.resolve (repoName).resolve (subfolder));            
             current.put (repoName, result);
         }
         return result;

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -748,28 +748,6 @@ public class SettingsRepo extends JScrollPane implements Settings
     {
         status ("<html><span style=\"color:green\">" + message + "</span></html>");
     }
-
-//    public MDir getModels (String repoName)
-//    {
-//        MDir result = (MDir) existingModels.get (repoName);
-//        if (result == null)
-//        {
-//            result = new MDir (repoName, reposDir.resolve (repoName).resolve ("models"));
-//            existingModels.put (repoName, result);
-//        }
-//        return result;
-//    }
-
-//    public MDir getReferences (String repoName)
-//    {
-//        MDir result = (MDir) existingReferences.get (repoName);
-//        if (result == null)
-//        {
-//            result = new MDir (repoName, reposDir.resolve (repoName).resolve ("references"));
-//            existingReferences.put (repoName, result);
-//        }
-//        return result;
-//    }
     
     public MDir getExisting (String subfolder, String repoName)
     {

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -167,12 +167,12 @@ public class SettingsRepo extends JScrollPane implements Settings
     // duplicate MDir instances. The goal is to maintain the guarantee of object identity.
     // These two collections may grow to be larger than the set in use by AppData, but entries that
     // coincide with AppData entries must reference exactly the same MDir instance.
-    protected Map<String,MNode> existingModels;
-    protected Map<String,MNode> existingReferences;
+    protected Map<String,MNode>              existingModels;
+    protected Map<String,MNode>              existingReferences;
     protected Map<String, Map<String,MNode>> existingOthers = new HashMap<String, Map<String,MNode>> ();
-    protected boolean           needRebuild;     // need to re-collate AppData.models and AppData.references
-    protected boolean           needSave = true; // need to flush repositories to disk for git status
-    protected Path              reposDir           = Paths.get (AppData.properties.get ("resourceDir")).resolve ("repos");
+    protected boolean                        needRebuild;     // need to re-collate AppData.models and AppData.references
+    protected boolean                        needSave = true; // need to flush repositories to disk for git status
+    protected Path                           reposDir           = Paths.get (AppData.properties.get ("resourceDir")).resolve ("repos");
 
     protected int                     timeout = 30;  // seconds; for git operations
     protected SshSessionFactory       sessionFactory;

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -1070,8 +1070,6 @@ public class SettingsRepo extends JScrollPane implements Settings
                     if (AppData.repos.child (newName) != null) return;
                     // Now we have a legitimate name change.
 
-//                    existing.forEach ((k,v) -> getExisting(k, oldName));                    
-//                    existing.forEach ((k,v) -> v.put (newName, getExisting(k, oldName)));
                     for (Entry<String, Map<String, MNode>> e : existing.entrySet ())
                     {
                         String k = e.getKey ();

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -50,7 +50,6 @@ import java.util.EventObject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -180,7 +179,7 @@ public class SettingsRepo extends JScrollPane implements Settings
     {
         instance = this;
         
-        AppData.others.forEach ((k, v) -> existing.put (k, v.getContainerMap ()));
+        AppData.documents.forEach (c -> existing.put (c.key (), ((MCombo) c).getContainerMap ()));
 
         setName ("Repositories");  // Necessary to fulfill Settings interface.
         JPanel panel = new JPanel ();
@@ -683,7 +682,7 @@ public class SettingsRepo extends JScrollPane implements Settings
         // Determine which repo holds key
         String pieces[] = path.split ("/");
         MDir source;
-        source = (MDir) AppData.others.get (pieces[0]).containerFor (pieces[1]);
+        source = (MDir) ((MCombo) AppData.documents.child (pieces[0])).containerFor (pieces[1]);
         String repoName = source.key ();
         String primary = AppData.state.get ("Repos", "primary");
         boolean sourceEditable =  AppData.repos.getBoolean (repoName, "editable")  ||  repoName.equals (primary);
@@ -714,7 +713,7 @@ public class SettingsRepo extends JScrollPane implements Settings
                     MCombo combo;
                     
                     destination = (MDir) existing.get (pieces[0]).get (key);
-                    combo = AppData.others.get (pieces[0]);
+                    combo = (MCombo) AppData.documents.child (pieces[0]);
                     
                     destination.take (source, pieces[1]);
                     combo.childDeleted (pieces[1]);  // Not actually deleted. This just forces an update of the children map.
@@ -827,7 +826,7 @@ public class SettingsRepo extends JScrollPane implements Settings
                 });
             }
         }
-        AppData.others.forEach ((k,v) -> v.init (existingContainers.get (k))); // Triggers change() call to PanelModel and PanelReference)
+        AppData.documents.forEach (c -> ((MCombo) c).init (existingContainers.get (c.key ()))); // Triggers change() call to PanelModel and PanelReference)
         needRebuild = false;
     }
 

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -810,11 +810,12 @@ public class SettingsRepo extends JScrollPane implements Settings
 
     public boolean isEmpty (String key)
     {
-        ArrayList<MNode> dirs = new ArrayList<> ();
-        existing.forEach ((k,v) -> dirs.add(getExisting(k, key)));
-        boolean empty = true;
-        for(MNode e: dirs) empty = empty && (e.size () == 0);
-        return empty;
+        for(String k : existing.keySet ())
+        {
+            MNode current = getExisting(k, key);
+            if (current.size () != 0) return false;
+        }
+        return true;
     }
 
     public void pull (GitWrapper gitRepo, String key)

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -800,7 +800,6 @@ public class SettingsRepo extends JScrollPane implements Settings
                 }
             }
         }
-        // Iterate over each container and initialize the corresponding MCombo.
         existingContainers.forEach ((k, v) -> ((MCombo) AppData.documents.childOrCreate (k)).init(v)); // Triggers change() call to PanelModel and PanelReference)
         needRebuild = false;
     }

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -1070,8 +1070,16 @@ public class SettingsRepo extends JScrollPane implements Settings
                     if (AppData.repos.child (newName) != null) return;
                     // Now we have a legitimate name change.
 
-                    existing.forEach ((k,v) -> v.remove (oldName));
-                    existing.forEach ((k,v) -> v.put (newName, getExisting(k, oldName)));
+//                    existing.forEach ((k,v) -> getExisting(k, oldName));                    
+//                    existing.forEach ((k,v) -> v.put (newName, getExisting(k, oldName)));
+                    for (Entry<String, Map<String, MNode>> e : existing.entrySet ())
+                    {
+                        String k = e.getKey ();
+                        Map<String, MNode> v = e.getValue ();
+                        MNode current = getExisting(k, oldName);
+                        v.remove (oldName);
+                        v.put (newName, current);                        
+                    }
 
                     gitRepos.get (row).close ();  // Shut down git under oldName
                     Path repoDir = reposDir.resolve (newName);

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -1073,7 +1073,7 @@ public class SettingsRepo extends JScrollPane implements Settings
 
                     gitRepos.get (row).close ();  // Shut down git under oldName
                     Path repoDir = reposDir.resolve (newName);
-                    existing.forEach ((k,v) -> getExisting(k, oldName).set (k)); // Flushes write queue, so save thread won't interfere with the move.
+                    existing.forEach ((k,v) -> getExisting(k, oldName).set (repoDir.resolve (k))); // Flushes write queue, so save thread won't interfere with the move.
                     AppData.repos.move (oldName, newName);
                     GitWrapper newWrapper = new GitWrapper (repoDir.resolve (".git"));
                     gitRepos.set (row, newWrapper);

--- a/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
+++ b/N2A/src/gov/sandia/n2a/ui/settings/SettingsRepo.java
@@ -180,8 +180,8 @@ public class SettingsRepo extends JScrollPane implements Settings
     {
         instance = this;
         
-        AppData.documents.forEach (c -> existing.put (c.key (), ((MCombo) c).getContainerMap ()));
-
+        for (MNode c : AppData.documents) existing.put (c.key (), ((MCombo) c).getContainerMap ());
+        
         setName ("Repositories");  // Necessary to fulfill Settings interface.
         JPanel panel = new JPanel ();
         setViewportView (panel);


### PR DESCRIPTION
Added HashMap to AppData as well as adjusted logic in SettingsRepo to support non-model and non-reference subfolders within a given repo. 