### PR TITLE
Adds GitHub actions tests on multiple Java versions/OSs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches:  [ master, development ]
+  pull_request:
+    branches:  [ master, development ]
+
+jobs:
+  build_and_test:
+
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '8', '11', '16', '17', '19' ]
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: Test on Java ${{ matrix.Java }} on ${{ matrix.runs-on }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK ${{ matrix.Java }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.Java }}
+        distribution: 'temurin'
+
+    - name: Test with Maven
+      run: |
+          cd N2A
+          mvn install
+
+    - name: Further tests, non Win
+      if: ${{ matrix.runs-on != 'windows-latest' }}
+      run: |
+        pwd
+        ls -alt
+        mvn dependency:tree
+        
+        # ...
+        
+    - name: Further tests, Windows
+      if: ${{ matrix.runs-on == 'windows-latest' }}
+      run: |
+        pwd
+        dir
+        mvn dependency:tree
+    
+        # ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8', '11', '16', '17', '19' ]
+        java: [ '16', '17', '19' ]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     name: Test on Java ${{ matrix.Java }} on ${{ matrix.runs-on }}
@@ -39,7 +39,6 @@ jobs:
       run: |
         pwd
         ls -alt
-        mvn dependency:tree
         
         # ...
         
@@ -48,6 +47,5 @@ jobs:
       run: |
         pwd
         dir
-        mvn dependency:tree
     
         # ...


### PR DESCRIPTION
@frothga I was just testing this on my local machine and noticed it doesn't work with versions of Java earlier than 15. Is this intentional?

Also, are there commandline options which can be used to generate/simulate some models, which could be added to these tests (e.g. load a model convert it to lems/neuroml, which could then be checked for validity/simulated)?